### PR TITLE
fix the build on EL8 systems to use the default compiler

### DIFF
--- a/devel3-on-almalinux8/10_create_directories.sh
+++ b/devel3-on-almalinux8/10_create_directories.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+# Create the directories and set environment variables
+
+# The following directory will be the top level of the Synergia build tree
+SYNHOME=${HOME}/syn2-devel3
+
+# load the mpi module
+
+module load mpi
+
+mkdir -p ${SYNHOME}/src
+export SRC=${SYNHOME}/src
+mkdir -p ${SYNHOME}/build
+export BLD=${SYNHOME}/build
+mkdir -p ${SYNHOME}/install
+export SYNINSTALL=${SYNHOME}/install
+
+# put install directory in paths
+if echo ${PATH} | grep -qv syn2-dev
+then
+    PATH=${SYNINSTALL}/bin:$PATH
+fi
+
+if echo ${LD_LIBRARY_PATH} | grep -qv syn2-dev
+then
+    if [ -z ${LD_LIBRARY_PATH} ]
+    then
+        export LD_LIBRARY_PATH=${SYNINSTALL}/lib
+    else
+        export LD_LIBRARY_PATH=${SYNINSTALL}/lib:$LD_LIBRARY_PATH
+    fi
+fi
+
+# the python executable
+PY_EXE=/usr/bin/python3
+
+# the name of the directory under which site-packages will be installed
+export PY_VER=$( ${PY_EXE} -c 'import sys; print("python{}.{}".format(sys.version_info.major, sys.version_info.minor))' )
+echo "python version string is " $PY_VER

--- a/devel3-on-almalinux8/22_install-fftw.sh
+++ b/devel3-on-almalinux8/22_install-fftw.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+. 10_create_directories.sh
+
+make_fftw=true
+
+if $make_fftw
+then
+    cd ${SRC}
+
+    FFTWSRC=${SRC}/fftw
+    if [ -d ${FFTWSRC} ]
+    then
+        echo "fftw already exists.  Won't proceed"
+        exit
+    fi
+
+    FFTWURL="https://www.fftw.org/fftw-3.3.10.tar.gz"
+    curl --insecure "${FFTWURL}" | tar xzvf -
+    mv fftw-3* fftw
+
+
+    if [ ! -d ${FFTWSRC} ]
+    then
+        echo "fftw has not been properly downloaded"
+        exit 10
+    fi
+
+    cd ${FFTWSRC}
+    ./configure --prefix=${SYNINSTALL} --disable-fortran --enable-mpi --enable-openmp --enable-shared --disable-dependency-tracking  |& tee fftw3_configure.out
+    make |& tee fftw3_make.out
+    make install |& tee fftw3_makeinstall.out
+
+fi # if make_fftw
+

--- a/devel3-on-almalinux8/55_install-synergia2.sh
+++ b/devel3-on-almalinux8/55_install-synergia2.sh
@@ -1,0 +1,181 @@
+#!/bin/bash
+
+# ensure directories and environment variables are set
+. ./10_create_directories.sh
+
+if [ -z "${PYTHONPATH}" ]
+then
+    export PYTHONPATH=${SYNINSTALL}/lib:${SYNINSTALL}/lib/${PY_VER}/site-packages:${SYNINSTALL}/lib64:${SYNINSTALL}/lib64/${PY_VER}/site-packages
+else
+    export PYTHONPATH=${SYNINSTALL}/lib:${SYNINSTALL}/lib/${PY_VER}/site-packages:${SYNINSTALL}/lib64:${SYNINSTALL}/lib64/${PY_VER}/site-packages:${PYTHONPATH}
+fi
+
+export SYNSRC=${SRC}/synergia2
+
+make_synergia2=true
+
+overwrite=0
+reinstall=0
+download=1
+
+if $make_synergia2
+then
+    while [ $# -gt 0 ]
+    do
+        if [ $# -gt 0 -a  "$1" = "reinstall" ]
+        then
+            reinstall=1
+	    echo "reinstall: $reinstall should be 1"
+            shift
+        elif [ $# -gt 0 -a  "$1" = "overwrite" ]
+        then
+            overwrite=1
+	    echo "overwrite: $overwrite should be 1"
+            shift
+	else
+	    echo "arguments can be overwrite or reinstall"
+	    exit 20
+        fi
+    done
+
+    if [ $reinstall -ne 0 ]
+    then
+	echo "Reconfiguring and installing"
+        download=0
+    fi
+    if [ $overwrite -ne 0 ]
+    then
+	echo "overwriting and installing"
+        rm -rf ${SYNSRC}
+        download=1
+    fi
+
+    if [ -d ${SYNSRC} ]
+    then
+	if [ $reinstall -ne 0 ]
+        then
+            download=0
+            echo "reconfiguring existing Synergia source"
+        else
+            echo "synergia2 already exists.  Do:"
+            echo "    $0 reinstall"
+            exit
+        fi
+    else
+        download=1
+    fi
+
+    #exit 20
+    cd ${SRC}
+
+    if [ $download -ne 0 ]
+    then
+        if git clone -b devel3 --recurse-submodules https://github.com/fnalacceleratormodeling/synergia2.git |& tee synergia2.git-clone.out
+        then
+            echo "You got synergia2!"
+        else
+            echo "Drat!  Something went wrong downloading synergia2"
+            exit 10
+        fi
+    fi
+
+    if [ ! -d ${SYNSRC} ]
+    then
+        echo "synergia2 has not been properly cloned"
+        exit 10
+    fi
+
+    # edit utils/CMakeLists.txt to add the stdc++fs library needed
+    # for g++-8.5 to find std::filesystem library.
+    CMLF=${SYNSRC}/src/synergia/utils/CMakeLists.txt
+    if grep "target_link_libraries(synergia_serialiation" |  grep -q stdc++fs >/dev/null
+    then
+        # stdc11fs is already there so I don't need to put it in.
+        true
+    else
+        sed -e 's/target_link_libraries(synergia_serialization synergia_parallel_utils)/target_link_libraries(synergia_serialization synergia_parallel_utils stdc++fs)/' -i ${CMLF}
+    fi
+
+    SYNBLD=${BLD}/synergia2
+    mkdir -p ${SYNBLD}
+    cd ${SYNBLD}
+
+    # on zlorfik, the FFTW libraries aren't found correctly without help
+    export FFTW_INC=${SYNINSTALL}/include
+    export FFTW_DIR=${SYNINSTALL}
+
+#  -DEIGEN3_INCLUDE_DIR=$LOCAL_ROOT/include/eigen3 \
+#  -DHDF5_ROOT=$LOCAL_ROOT \
+
+
+  cmake -DCMAKE_INSTALL_PREFIX=${SYNINSTALL} \
+  -DFFTW3_INCLUDE_DIR=${FFTW_INC} -DFFTW3_LIBRARIES=${FFTW_DIR}/lib/libfftw3.so -DFFTW3_MPI_LIBRARIES=${FFTW_DIR}/lib/libfftw3_mpi.so -DFFTW3_OMP_LIBRARIES=${FFTW_DIR}/lib/libfftw3_omp.so \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DENABLE_CUDA=off \
+  -DENABLE_OPENMP=on \
+  -DALLOW_PADDING=on \
+  -DBUILD_PYTHON_BINDINGS=on \
+  -DPYTHON_EXECUTABLE=${PY_EXE} \
+  -DSIMPLE_TIMER=off \
+  ${SYNSRC} |& tee synergia2.cmake.out
+
+    if [ $? -eq 0 ]
+    then
+        echo "synergia2 cmake worked"
+    else
+        echo "Drat!! synergia2 cmake failed"
+        exit 10
+    fi
+
+    make VERBOSE=t  |& tee synergia2.make.out
+    if [ $? -eq 0 ]
+    then
+        echo "Congratulations!! synergia2 is make worked !!!"
+    else
+        echo "Drat!! something went wrong building synergia2"
+        exit 10
+    fi
+
+    if make install |& tee synergia2.install.out
+    then
+        echo "Congratulations!! synergia2 is installed!!!"
+    else
+        echo "Drat!! something went wrong installing synergia2"
+        exit 10
+    fi
+
+fi # if make_synergia2
+
+# Python modules installation for Synergia is currently broken.  Disable
+# the site-packages directory and just use the structure from the build
+# directories.
+mv ${SYNINSTALL}/lib/${PY_VER}/site-packages/synergia2 ${SYNINSTALL}/lib/${PY_VER}/site-packages/synergia2-ng
+PYTHONPATH=${SYNBLD}/src:${PYTHONPATH}
+
+echo "Define these environment variables:"
+echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}"
+echo "PYTHONPATH=${PYTHONPATH}"
+
+cat >${SYNINSTALL}/bin/setup.sh <<EOF
+#!/bin/bash
+
+# load the mpi module
+
+module load mpi
+
+PATH=${SYNINSTALL}/bin:\${PATH}
+if [ -n "\${LD_LIBRARY_PATH}" ]
+then
+    export LD_LIBRARY_PATH=${SYNINSTALL}/lib:${SYNINSTALL}/lib64:\${LD_LIBRARY_PATH}
+else
+    export LD_LIBRARY_PATH=${SYNINSTALL}/lib:${SYNINSTALL}/lib64
+fi
+if [ -n "\${PYTHONPATH}" ]
+then
+    export PYTHONPATH=${SYNINSTALL}/lib:${SYNINSTALL}/lib/${PY_VER}/site-packages:${SYNINSTALL}/lib64/${PY_VER}/site-packages:\${PYTHONPATH}
+else
+    export PYTHONPATH=${SYNINSTALL}/lib:${SYNINSTALL}/lib/${PY_VER}/site-packages:${SYNINSTALL}/lib64/${PY_VER}/site-packages
+fi
+EOF
+
+echo "or source file ${SYNINSTALL}/bin/setup.sh"

--- a/devel3-on-almalinux8/README.md
+++ b/devel3-on-almalinux8/README.md
@@ -1,5 +1,33 @@
-# Building Synergia2 devel3 branch on the an EL8 (CentOS8, AlmaLinux8) machine with using gcc8 and installed packages
+# Building Synergia2 devel3 branch on the an EL8 (CentOS8, AlmaLinux8) machine using gcc9 from gcc-toolset-9 and installed packages
 
-## This directory is obsolete.
+These scripts will build the devel3 branch of Synergia on
+an EL8 based system using most packages installed from rpms except for
+ MPI/OpenMP enabled FFTW3.
+Packages come from the `powertools`,  `plus` and `EPEL` repositories.
 
-Synergia has to be built with gcc > 9.  See the scripts in devel3-on-almalinux-8-gcc9
+With the use of `std::filesystem`, the serialization code needs to be
+linked with the stdc++fs library. The synergia build script edits the file
+to make that happen.
+
+Adjust the install directory in the file 10_create_directories.sh.
+This file is sourced by the other files.  The default installation directory
+is `$HOME/syn2-devel3`.
+
+Execute files in order:
+
+```
+bash 22_install-fftw.sh
+bash 55_install-synergia.sh
+```
+
+The `55_install-synergia2.sh` script accepts an argument:
+<dl>
+    <dt> <em>overwrite</em> </dt>
+    <dd> Erases and redownloads Synergia </dd>
+    <dt> <em>reinstall</em> </dt>
+    <dd> Reconfigures without downloading (cmake), builds and installs </dd>
+</dl>
+
+The libraries and executables will be installed in the `install` subdirectory with binaries installed in `install/bin`, libraries in `install/lib` and Python modules in `install/lib/python3.6/site-packages`.
+
+The installation also creates a setup script in `install/bin/setup.sh` which should be sourced to load all the correct modules and set up path environment variables.


### PR DESCRIPTION
Restored build scripts, adjusting them to use the builtin gcc-8.5.0 compiler with extra code that alters utils/CMakeLists.txt file to add the stdc++fs library required by the use of std::filesystem which is "experimental" in gcc-8.